### PR TITLE
Fix the displacement offset for moffset-encoded operands

### DIFF
--- a/arch/X86/X86DisassemblerDecoder.c
+++ b/arch/X86/X86DisassemblerDecoder.c
@@ -1999,6 +1999,15 @@ static int readOperands(struct InternalInstruction* insn)
 			case ENCODING_Ia:
 				if (readImmediate(insn, insn->addressSize))
 					return -1;
+				/* Direct memory-offset (moffset) immediate will get mapped
+				   to memory operand later. We want the encoding info to
+				   reflect that as well. */
+				insn->displacementOffset = insn->immediateOffset;
+				insn->consumedDisplacement = true;
+				insn->displacementSize = insn->immediateSize;
+				insn->displacement = insn->immediates[insn->numImmediatesConsumed - 1];
+				insn->immediateOffset = 0;
+				insn->immediateSize = 0;
 				break;
 
 			case ENCODING_IRC:


### PR DESCRIPTION
This was initially introduced in dce7da9 but lost in the LLVM 7 sync
in 5a99624.