### PR TITLE
Change version in pkgconfig.mk

### DIFF
--- a/pkgconfig.mk
+++ b/pkgconfig.mk
@@ -2,11 +2,11 @@
 # To be used to generate capstone.pc for pkg-config
 
 # version major & minor 
-PKG_MAJOR = 5
+PKG_MAJOR = 4
 PKG_MINOR = 0
 
 # version bugfix level. Example: PKG_EXTRA = 1
-PKG_EXTRA = 0
+PKG_EXTRA = 2
 
 # version tag. Examples: rc1, b2, post1
-PKG_TAG =
+PKG_TAG = 0


### PR DESCRIPTION
We want to regard our fork as being the currently released version
with some patches applied, insead of a pre-release of the next
version.  So we roll back the version to 4.0.1, and use PKG_TAG to
track our fork's version.