### PR TITLE
Updating PKG_TAG=6 in pkgconfig.mk

### DIFF
--- a/pkgconfig.mk
+++ b/pkgconfig.mk
@@ -9,4 +9,4 @@ PKG_MINOR = 0
 PKG_EXTRA = 2
 
 # version tag. Examples: rc1, b2, post1
-PKG_TAG = 2
+PKG_TAG = 6


### PR DESCRIPTION
Updating PKG_TAG to 6 in order to exceed the release of capstone-4.0.2-5 on centos7. This will ensure our packages will not be overwritten by the public capstone packages.