### PR TITLE
Add handling of NOTRACK

### DIFF
--- a/arch/X86/X86Mapping.c
+++ b/arch/X86/X86Mapping.c
@@ -1819,6 +1819,27 @@ static bool valid_repe(cs_struct *h, unsigned int opcode)
 	return false;
 }
 
+// given MCInst's id, find out if this insn is valid for NOTRACK prefix
+// NOTRACK prefix is valid for CALL/JMP
+static bool valid_notrack(cs_struct *h, unsigned int opcode)
+{
+	unsigned int id;
+	unsigned int i = find_insn(opcode);
+	if (i != -1) {
+		id = insns[i].mapid;
+		switch(id) {
+			default:
+				return false;
+			case X86_INS_CALL:
+			case X86_INS_JMP:
+                return true;
+		}
+	}
+
+	// not found
+	return false;
+}
+
 #ifndef CAPSTONE_DIET
 // add *CX register to regs_read[] & regs_write[]
 static void add_cx(MCInst *MI)
@@ -1946,6 +1967,17 @@ bool X86_lockrep(MCInst *MI, SStream *O)
 #endif
 			break;
 	}
+
+	switch(MI->x86_prefix[1]) {
+		default:
+			break;
+		case 0x3e:
+			opcode = MCInst_getOpcode(MI);
+			if (valid_notrack(MI->csh, opcode)) {
+				SStream_concat(O, "notrack|");
+            }
+			break;
+    }
 
 	// copy normalized prefix[] back to x86.prefix[]
 	if (MI->csh->detail)

--- a/arch/X86/X86Mapping.c
+++ b/arch/X86/X86Mapping.c
@@ -1832,7 +1832,7 @@ static bool valid_notrack(cs_struct *h, unsigned int opcode)
 				return false;
 			case X86_INS_CALL:
 			case X86_INS_JMP:
-                return true;
+				return true;
 		}
 	}
 

--- a/arch/X86/X86Mapping.c
+++ b/arch/X86/X86Mapping.c
@@ -1819,8 +1819,8 @@ static bool valid_repe(cs_struct *h, unsigned int opcode)
 	return false;
 }
 
-// given MCInst's id, find out if this insn is valid for NOTRACK prefix
-// NOTRACK prefix is valid for CALL/JMP
+// Given MCInst's id, find out if this insn is valid for NOTRACK prefix.
+// NOTRACK prefix is valid for CALL/JMP.
 static bool valid_notrack(cs_struct *h, unsigned int opcode)
 {
 	unsigned int id;

--- a/arch/X86/X86Mapping.c
+++ b/arch/X86/X86Mapping.c
@@ -1975,9 +1975,9 @@ bool X86_lockrep(MCInst *MI, SStream *O)
 			opcode = MCInst_getOpcode(MI);
 			if (valid_notrack(MI->csh, opcode)) {
 				SStream_concat(O, "notrack|");
-            }
+			}
 			break;
-    }
+	}
 
 	// copy normalized prefix[] back to x86.prefix[]
 	if (MI->csh->detail)

--- a/suite/cstest/issues.cs
+++ b/suite/cstest/issues.cs
@@ -1,3 +1,11 @@
+!# issue 1997 notrack jmp
+!# CS_ARCH_X86, CS_MODE_64, None
+0x3e,0xff,0xe0 == notrack jmp rax
+
+!# issue 1997 notrack call
+!# CS_ARCH_X86, CS_MODE_64, None
+0x3e,0xff,0xd0 == notrack call rax
+
 !# issue 1873 AArch64 missing VAS specifiers in aliased instructions
 !# CS_ARCH_ARM64, CS_MODE_ARM, CS_OPT_DETAIL
 0x21,0x04,0x03,0x5e == mov b1, v1.b[1] ; operands[1].vas: 0x4 ; operands[1].vector_index: 1


### PR DESCRIPTION
It is handled by patching mnemonics as other prefixes are done, such as lock or rep.